### PR TITLE
Add --skip-dirty-repos flag to skip repositories with uncommitted changes

### DIFF
--- a/src/commands/git_repos.rs
+++ b/src/commands/git_repos.rs
@@ -7,12 +7,12 @@ use crate::repository::Repository;
 use crate::services::git_repos_service::GitReposService;
 use crate::task_result::TaskResult;
 
-pub fn run(path: Option<PathBuf>, dry: bool) -> Result<i32> {
+pub fn run(path: Option<PathBuf>, dry: bool, skip_dirty_repos: bool) -> Result<i32> {
     let path = path
         .map(Ok)
         .unwrap_or_else(env::current_dir)?
         .canonicalize()?;
-    let service = GitReposService::new_with_dry_run(dry);
+    let service = GitReposService::new(dry, skip_dirty_repos);
     let result = service.handle_all_git_repos(&path)?;
 
     let exit_code = match &result {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -159,6 +159,16 @@ impl GitRepo {
             .with_context(|| format!("failed to checkout default branch '{}'", branch))
     }
 
+    pub fn is_dirty(&self) -> Result<bool> {
+        #[cfg(feature = "git2-backend")]
+        {
+            return git2_backend::find_dirty_worktree(self).map(|w| w.is_some());
+        }
+
+        let output = self.run_and_capture("git", &["status", "--porcelain"])?;
+        Ok(!output.trim().is_empty())
+    }
+
     #[cfg(not(feature = "git2-backend"))]
     fn get_upstream_status(&self, local: &str, upstream: &str) -> Result<UpstreamStatus> {
         if !self.branch_exists(upstream)? {

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -71,6 +71,7 @@ mod tests {
         let status = Command::new("tar")
             .arg("xzf")
             .arg(&tarball_path)
+            .arg("--no-same-owner")
             .current_dir(temp_dir.path())
             .status()?;
 

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -68,6 +68,8 @@ mod tests {
             .join("fixtures")
             .join(format!("{}.tar.gz", repo_name));
 
+        // --no-same-owner prevents tar (when run as root) from preserving the
+        // fixture's original UID, which would trigger git's safe.directory check.
         let status = Command::new("tar")
             .arg("xzf")
             .arg(&tarball_path)

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,9 @@ enum Command {
         /// Dry run mode - analyze without performing actions or prompting
         #[arg(long)]
         dry: bool,
+        /// Skip repositories with uncommitted changes
+        #[arg(long)]
+        skip_dirty_repos: bool,
     },
 }
 
@@ -48,8 +51,8 @@ fn main() -> Result<()> {
 
     match cli.command {
         Command::Clean { path, dry } => commands::git_clean::run(path, dry)?,
-        Command::Repos { path, dry } => {
-            let exit_code = commands::git_repos::run(path, dry)?;
+        Command::Repos { path, dry, skip_dirty_repos } => {
+            let exit_code = commands::git_repos::run(path, dry, skip_dirty_repos)?;
             std::process::exit(exit_code);
         }
     }

--- a/src/services/git_repos_service.rs
+++ b/src/services/git_repos_service.rs
@@ -12,11 +12,12 @@ use crate::ui::{DialoguerPrompt, DryRunPrompt};
 
 pub struct GitReposService {
     dry_run: bool,
+    skip_dirty_repos: bool,
 }
 
 impl GitReposService {
-    pub fn new_with_dry_run(dry_run: bool) -> Self {
-        Self { dry_run }
+    pub fn new(dry_run: bool, skip_dirty_repos: bool) -> Self {
+        Self { dry_run, skip_dirty_repos }
     }
 
     pub fn handle_all_git_repos(&self, path: &Path) -> Result<TaskResult> {
@@ -62,6 +63,11 @@ impl GitReposService {
             }
         } else {
             let repo = GitRepo::new(dir.to_path_buf());
+
+            if self.skip_dirty_repos && repo.is_dirty()? {
+                return Ok(GitResult::Clean);
+            }
+
             let branches = repo.get_branches()?;
             let branches_needing_action: Vec<Branch> = branches
                 .into_iter()


### PR DESCRIPTION
## Summary
This PR adds a new `--skip-dirty-repos` command-line flag that allows users to skip processing repositories with uncommitted changes when running the `repos` command.

## Key Changes
- **Added `is_dirty()` method to `GitRepo`**: New public method that checks if a repository has uncommitted changes by running `git status --porcelain`, with support for the git2 backend when available
- **Extended `GitReposService`**: 
  - Added `skip_dirty_repos` field to track the flag state
  - Renamed `new_with_dry_run()` to `new()` and added `skip_dirty_repos` parameter
  - Added logic to skip processing repositories that are dirty when the flag is enabled
- **Updated CLI argument parsing**: Added `--skip-dirty-repos` boolean flag to the `Repos` command in `main.rs`
- **Updated command handler**: Modified `git_repos::run()` to accept and pass through the `skip_dirty_repos` parameter

## Implementation Details
- When `skip_dirty_repos` is enabled and a repository is detected as dirty, the service returns `GitResult::Clean` to skip further processing
- The dirty check is performed early in the repository processing pipeline, before fetching branches
- The implementation supports both the git2 backend (when available) and the standard git CLI fallback

https://claude.ai/code/session_01K6fPf9rAusaJju1EuTHFHM