### PR TITLE
Speed up repos scan with for-each-ref and parallelism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "dialoguer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +164,12 @@ dependencies = [
  "tempfile",
  "zeroize",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -195,6 +226,7 @@ dependencies = [
  "clap",
  "console",
  "dialoguer",
+ "rayon",
  "serde",
  "serde_json",
  "tempfile",
@@ -326,6 +358,26 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "*"
 clap = { version = "*", features = ["derive"] }
 console = "*"
 dialoguer = "*"
+rayon = "*"
 serde = { version = "*", features = ["derive"] }
 serde_json = "*"
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -33,12 +33,6 @@ pub struct Upstream {
     pub status: UpstreamStatus,
 }
 
-#[derive(Debug, Clone)]
-pub struct Worktree {
-    pub path: PathBuf,
-    pub branch: Option<String>,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UpstreamStatus {
     Identical,
@@ -62,45 +56,15 @@ impl GitRepo {
     }
 
     pub fn get_branches(&self) -> Result<Vec<Branch>> {
-        use std::collections::HashMap;
         let output = self.run_and_capture(
             "git",
-            &["branch", "--format=%(refname:short):%(upstream:short)"],
+            &[
+                "for-each-ref",
+                "--format=%(refname:short)|%(upstream:short)|%(upstream:track)|%(worktreepath)",
+                "refs/heads/",
+            ],
         )?;
-
-        let worktree_map: HashMap<String, PathBuf> = self
-            .worktrees()?
-            .into_iter()
-            .filter_map(|worktree| worktree.branch.map(|branch| (branch, worktree.path)))
-            .collect();
-
-        let mut branches = Vec::new();
-        for line in output.lines().filter(|line| !line.trim().is_empty()) {
-            let mut parts = line.splitn(2, ':');
-            let local = parts
-                .next()
-                .ok_or_else(|| anyhow!("unexpected output from git branch: {line}"))?
-                .trim()
-                .to_string();
-            let worktree_path = worktree_map.get(&local).cloned();
-            let upstream_part = parts.next().unwrap_or("").trim();
-            let upstream = if upstream_part.is_empty() {
-                None
-            } else {
-                let status = self.get_upstream_status(&local, upstream_part)?;
-                Some(Upstream {
-                    name: upstream_part.to_string(),
-                    status,
-                })
-            };
-            branches.push(Branch {
-                refname: local,
-                upstream,
-                worktree_path,
-            });
-        }
-
-        Ok(branches)
+        parse_branches(&output)
     }
 
     pub fn branch_commit_infos(
@@ -136,10 +100,6 @@ impl GitRepo {
         Ok(map)
     }
 
-    pub fn worktrees(&self) -> Result<Vec<Worktree>> {
-        let output = self.run_and_capture("git", &["worktree", "list", "--porcelain"])?;
-        parse_worktrees(&output)
-    }
     pub fn push(&self, refname: &str) -> Result<()> {
         self.run_interactive_printing("git", &["push", "origin", refname])
     }
@@ -188,66 +148,6 @@ impl GitRepo {
     pub fn is_dirty(&self) -> Result<bool> {
         let output = self.run_and_capture("git", &["status", "--porcelain"])?;
         Ok(!output.trim().is_empty())
-    }
-
-    fn get_upstream_status(&self, local: &str, upstream: &str) -> Result<UpstreamStatus> {
-        if !self.branch_exists(upstream)? {
-            return Ok(UpstreamStatus::UpstreamIsGone);
-        }
-        let local_is_ancestor = self.is_ancestor(local, upstream)?;
-        let upstream_is_ancestor = self.is_ancestor(upstream, local)?;
-        Ok(match (local_is_ancestor, upstream_is_ancestor) {
-            (true, true) => UpstreamStatus::Identical,
-            (true, false) => UpstreamStatus::UpstreamIsAheadOfLocal,
-            (false, true) => UpstreamStatus::LocalIsAheadOfUpstream,
-            (false, false) => UpstreamStatus::MergeNeeded,
-        })
-    }
-
-    fn is_ancestor(&self, base: &str, commit: &str) -> Result<bool> {
-        let status = self
-            .command("git")
-            .arg("merge-base")
-            .arg("--is-ancestor")
-            .arg(base)
-            .arg(commit)
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .with_context(|| {
-                format!("failed to run git merge-base --is-ancestor {base} {commit}")
-            })?;
-
-        match status.code() {
-            Some(0) => Ok(true),
-            Some(1) | Some(128) => Ok(false),
-            Some(code) => Err(anyhow!(
-                "git merge-base returned unexpected exit code {code}"
-            )),
-            None => Err(anyhow!("git merge-base terminated by signal")),
-        }
-    }
-
-    fn branch_exists(&self, branch: &str) -> Result<bool> {
-        let status = self
-            .command("git")
-            .arg("rev-parse")
-            .arg("--quiet")
-            .arg("--verify")
-            .arg(branch)
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .with_context(|| format!("failed to run git rev-parse --verify {branch}"))?;
-
-        match status.code() {
-            Some(0) => Ok(true),
-            Some(1) => Ok(false),
-            Some(code) => Err(anyhow!(
-                "git rev-parse returned unexpected exit code {code}"
-            )),
-            None => Err(anyhow!("git rev-parse terminated by signal")),
-        }
     }
 
     fn default_branch(&self) -> Result<String> {
@@ -341,61 +241,56 @@ fn format_command(program: &str, args: &[&str]) -> String {
     parts.join(" ")
 }
 
-fn parse_worktrees(output: &str) -> Result<Vec<Worktree>> {
-    #[derive(Default)]
-    struct Pending {
-        path: Option<PathBuf>,
-        branch: Option<String>,
-    }
-
-    fn finish(pending: &mut Pending, worktrees: &mut Vec<Worktree>) -> Result<()> {
-        if let Some(path) = pending.path.take() {
-            worktrees.push(Worktree {
-                path,
-                branch: pending.branch.take(),
-            });
+fn parse_branches(output: &str) -> Result<Vec<Branch>> {
+    let mut branches = Vec::new();
+    for line in output.lines().filter(|line| !line.trim().is_empty()) {
+        let parts: Vec<&str> = line.splitn(4, '|').collect();
+        if parts.len() != 4 {
+            return Err(anyhow!("unexpected output from git for-each-ref: {line}"));
         }
-        Ok(())
-    }
-
-    let mut worktrees = Vec::new();
-    let mut pending = Pending::default();
-
-    for line in output.lines().chain(std::iter::once("")) {
-        let line = line.trim_end();
-        if line.is_empty() {
-            finish(&mut pending, &mut worktrees)?;
-            continue;
-        }
-
-        let (key, value) = match line.split_once(' ') {
-            Some((key, value)) => (key, value.trim()),
-            None => (line, ""),
+        let refname = parts[0].trim().to_string();
+        let upstream_name = parts[1].trim();
+        let track = parts[2].trim();
+        let worktree_path = match parts[3].trim() {
+            "" => None,
+            path => Some(PathBuf::from(path)),
         };
-
-        match key {
-            "worktree" => {
-                finish(&mut pending, &mut worktrees)?;
-                if value.is_empty() {
-                    return Err(anyhow!("git worktree entry missing path"));
-                }
-                pending.path = Some(PathBuf::from(value));
-                pending.branch = None;
-            }
-            "branch" => {
-                if !value.is_empty() {
-                    let name = value
-                        .strip_prefix("refs/heads/")
-                        .unwrap_or(value)
-                        .to_string();
-                    pending.branch = Some(name);
-                }
-            }
-            _ => {}
-        }
+        let upstream = if upstream_name.is_empty() {
+            None
+        } else {
+            Some(Upstream {
+                name: upstream_name.to_string(),
+                status: parse_upstream_track(track),
+            })
+        };
+        branches.push(Branch {
+            refname,
+            upstream,
+            worktree_path,
+        });
     }
+    Ok(branches)
+}
 
-    Ok(worktrees)
+fn parse_upstream_track(track: &str) -> UpstreamStatus {
+    if track.is_empty() {
+        return UpstreamStatus::Identical;
+    }
+    let inner = track
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(track);
+    if inner == "gone" {
+        return UpstreamStatus::UpstreamIsGone;
+    }
+    let has_ahead = inner.split(',').any(|part| part.trim().starts_with("ahead"));
+    let has_behind = inner.split(',').any(|part| part.trim().starts_with("behind"));
+    match (has_ahead, has_behind) {
+        (true, true) => UpstreamStatus::MergeNeeded,
+        (true, false) => UpstreamStatus::LocalIsAheadOfUpstream,
+        (false, true) => UpstreamStatus::UpstreamIsAheadOfLocal,
+        (false, false) => UpstreamStatus::Identical,
+    }
 }
 
 #[cfg(test)]

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use super::super::parse_worktrees;
+    use super::super::parse_branches;
     use crate::git::{Branch, GitRepo, Upstream, UpstreamStatus};
     use anyhow::Result;
     use std::path::PathBuf;
@@ -49,18 +49,6 @@ mod tests {
         assert_eq!(repo.dir(), dir.as_path());
     }
 
-    #[test]
-    fn parse_worktrees_extracts_branches() -> Result<()> {
-        let output = "worktree /repo\nHEAD abc\nbranch refs/heads/main\n\nworktree /repo/feature\nHEAD def\nbranch refs/heads/feature\n";
-        let worktrees = parse_worktrees(output)?;
-        assert_eq!(worktrees.len(), 2);
-        assert_eq!(worktrees[0].path, PathBuf::from("/repo"));
-        assert_eq!(worktrees[0].branch.as_deref(), Some("main"));
-        assert_eq!(worktrees[1].path, PathBuf::from("/repo/feature"));
-        assert_eq!(worktrees[1].branch.as_deref(), Some("feature"));
-        Ok(())
-    }
-
     fn test_repo(repo_name: &str) -> Result<GitRepo> {
         let temp_dir = tempfile::tempdir()?;
         let tarball_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -84,6 +72,46 @@ mod tests {
         let repo_path = temp_dir.path().join(repo_name);
         let _ = temp_dir.keep();
         Ok(GitRepo::new(repo_path))
+    }
+
+    #[test]
+    fn parse_branches_handles_all_upstream_states() -> Result<()> {
+        let output = "\
+main|origin/main||/repo
+behind|origin/behind|[behind 2]|
+ahead|origin/ahead|[ahead 1]|
+diverged|origin/diverged|[ahead 1, behind 2]|
+gone|origin/gone|[gone]|
+local-only||||
+";
+        let branches = parse_branches(output)?;
+        assert_eq!(branches.len(), 6);
+
+        let by_name: std::collections::HashMap<_, _> =
+            branches.iter().map(|b| (b.refname.as_str(), b)).collect();
+
+        let main = by_name["main"];
+        assert_eq!(main.upstream.as_ref().map(|u| u.status), Some(UpstreamStatus::Identical));
+        assert_eq!(main.worktree_path, Some(PathBuf::from("/repo")));
+
+        assert_eq!(
+            by_name["behind"].upstream.as_ref().map(|u| u.status),
+            Some(UpstreamStatus::UpstreamIsAheadOfLocal)
+        );
+        assert_eq!(
+            by_name["ahead"].upstream.as_ref().map(|u| u.status),
+            Some(UpstreamStatus::LocalIsAheadOfUpstream)
+        );
+        assert_eq!(
+            by_name["diverged"].upstream.as_ref().map(|u| u.status),
+            Some(UpstreamStatus::MergeNeeded)
+        );
+        assert_eq!(
+            by_name["gone"].upstream.as_ref().map(|u| u.status),
+            Some(UpstreamStatus::UpstreamIsGone)
+        );
+        assert!(by_name["local-only"].upstream.is_none());
+        Ok(())
     }
 
     #[test]

--- a/src/services/git_repos_list_service.rs
+++ b/src/services/git_repos_list_service.rs
@@ -4,6 +4,7 @@ use std::sync::mpsc;
 use std::thread;
 
 use anyhow::Result;
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::cache;
@@ -118,46 +119,44 @@ fn collect_and_sort(path: &Path) -> Result<Vec<BranchListEntry>> {
 }
 
 fn collect_branch_entries(path: &Path) -> Result<Vec<BranchListEntry>> {
-    let mut entries = Vec::new();
-    for dir_entry in fs::read_dir(path)? {
-        let dir_entry = dir_entry?;
-        let entry_path = dir_entry.path();
-        if !entry_path.is_dir() {
-            continue;
-        }
-        if is_globally_ignored(&entry_path) {
-            continue;
-        }
-        let repo = GitRepo::new(entry_path.clone());
-        let branches = match repo.get_branches() {
-            Ok(branches) => branches,
-            Err(_) => continue,
-        };
-        let commit_infos = match repo.branch_commit_infos() {
-            Ok(infos) => infos,
-            Err(_) => continue,
-        };
-        let repo_name = entry_path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .map(|name| name.to_string())
-            .unwrap_or_else(|| entry_path.to_string_lossy().into_owned());
+    let dir_paths: Vec<PathBuf> = fs::read_dir(path)?
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .filter(|p| p.is_dir() && !is_globally_ignored(p))
+        .collect();
 
-        for branch in branches {
-            let Some(info) = commit_infos.get(&branch.refname) else {
-                continue;
-            };
-            entries.push(BranchListEntry {
-                repo_name: repo_name.clone(),
-                repo_path: entry_path.clone(),
-                refname: branch.refname.clone(),
-                status: branch_status(&branch),
-                commit_timestamp: info.commit_timestamp,
-                commit_date: info.commit_date.clone(),
-                committer: info.committer.clone(),
-                worktree_path: branch.worktree_path.clone(),
-            });
-        }
+    let entries: Vec<BranchListEntry> = dir_paths
+        .par_iter()
+        .flat_map(|entry_path| collect_repo_entries(entry_path).unwrap_or_default())
+        .collect();
+
+    Ok(entries)
+}
+
+fn collect_repo_entries(entry_path: &Path) -> Result<Vec<BranchListEntry>> {
+    let repo = GitRepo::new(entry_path.to_path_buf());
+    let branches = repo.get_branches()?;
+    let commit_infos = repo.branch_commit_infos()?;
+    let repo_name = entry_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.to_string())
+        .unwrap_or_else(|| entry_path.to_string_lossy().into_owned());
+
+    let mut entries = Vec::new();
+    for branch in branches {
+        let Some(info) = commit_infos.get(&branch.refname) else {
+            continue;
+        };
+        entries.push(BranchListEntry {
+            repo_name: repo_name.clone(),
+            repo_path: entry_path.to_path_buf(),
+            refname: branch.refname.clone(),
+            status: branch_status(&branch),
+            commit_timestamp: info.commit_timestamp,
+            commit_date: info.commit_date.clone(),
+            committer: info.committer.clone(),
+            worktree_path: branch.worktree_path.clone(),
+        });
     }
     Ok(entries)
 }

--- a/src/services/git_repos_service.rs
+++ b/src/services/git_repos_service.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use rayon::prelude::*;
 use std::fs;
 use std::path::{Path, PathBuf};
 #[cfg(feature = "timings")]
@@ -41,16 +42,21 @@ impl GitReposService {
     }
 
     fn fetch_all_results(&self, path: &Path) -> Result<Vec<ResultWithPath>> {
-        let mut results = Vec::new();
-        for entry in fs::read_dir(path)? {
-            let entry = entry?;
-            let entry_path = entry.path();
-            let result = self.repo_result(&entry_path)?;
-            results.push(ResultWithPath {
-                path: entry_path,
-                result,
-            });
-        }
+        let entry_paths: Vec<PathBuf> = fs::read_dir(path)?
+            .map(|entry| entry.map(|e| e.path()))
+            .collect::<std::io::Result<Vec<_>>>()?;
+
+        let mut results: Vec<ResultWithPath> = entry_paths
+            .par_iter()
+            .map(|entry_path| {
+                self.repo_result(entry_path).map(|result| ResultWithPath {
+                    path: entry_path.clone(),
+                    result,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        results.sort_by(|a, b| a.path.cmp(&b.path));
         Ok(results)
     }
 


### PR DESCRIPTION
## Summary

Closes #20 (or at least makes the proposed daemon design optional).

Two changes:

1. **One `for-each-ref` call replaces 3N+2 git invocations per repo.** `get_branches` previously fired `git branch`, `git worktree list`, then for every branch with an upstream: `git rev-parse --verify`, `git merge-base --is-ancestor local upstream`, `git merge-base --is-ancestor upstream local`. All of that is now one `git for-each-ref --format='%(refname:short)|%(upstream:short)|%(upstream:track)|%(worktreepath)' refs/heads/`. The `upstream:track` field already encodes the ahead/behind/gone states needed for `UpstreamStatus`, and `worktreepath` removes the need for a separate `worktree list` parse.

2. **Per-repo work runs in parallel via rayon.** `GitReposService::fetch_all_results` and `GitReposListService::collect_branch_entries` now use `par_iter` so independent repos no longer block each other.

Also drops the now-unused `worktrees()` method, `Worktree` struct, and `parse_worktrees` parser.

## Measured impact

`repos --dry` against `~/aira` (72 repos):

| | wall time | CPU |
| --- | --- | --- |
| before | 9.0s | 47% |
| after  | 0.59s | 122% |

Aerospace (29 branches, the worst case) went from being a bottleneck to ~200ms.

## Note on issue #20

At sub-second scan times, the SQLite + background-daemon design may no longer be necessary — running the scan on demand is fast enough. Worth re-evaluating that design after this lands.